### PR TITLE
Fix TypeSpec token decoding bug

### DIFF
--- a/CilTools.BytecodeAnalysis/TypeSpec.cs
+++ b/CilTools.BytecodeAnalysis/TypeSpec.cs
@@ -207,6 +207,13 @@ namespace CilTools.BytecodeAnalysis
         static int DecodeToken(uint decompressed) //ECMA-335 II.23.2.8 TypeDefOrRefOrSpecEncoded
         {
             byte table_index = (byte)((int)decompressed & 0x03);
+
+            //decode table index
+
+            if(table_index == 2) table_index = 0x1B; //TypeSpec
+            else if (table_index == 0) table_index = 0x02;//TypeDef
+            //TypeRef index is unchanged by encoding
+
             int value_index = ((int)decompressed & ~0x03) >> 2;
 
             byte[] value_bytes = BitConverter.GetBytes(value_index);
@@ -358,8 +365,9 @@ namespace CilTools.BytecodeAnalysis
 
                         uint numbounds = MetadataReader.ReadCompressed(source);
                         if (numbounds > 0) throw new NotSupportedException("Parsing array shapes that specify lower bounds is not supported");
-                                                
-                        restype = ts.Type.MakeArrayType((int)rank);                        
+
+                        if (ts.Type != null) restype = ts.Type.MakeArrayType((int)rank);
+                        
                         break;
                     case (byte)CilTools.BytecodeAnalysis.ElementType.SzArray:
                         ts = TypeSpec.ReadFromStream(source, resolver);
@@ -369,7 +377,9 @@ namespace CilTools.BytecodeAnalysis
                         break;
                     case (byte)CilTools.BytecodeAnalysis.ElementType.Ptr:
                         ts = TypeSpec.ReadFromStream(source, resolver);
-                        restype = ts.Type.MakePointerType();
+
+                        if (ts.Type != null) restype = ts.Type.MakePointerType();
+
                         break;
                     case (byte)CilTools.BytecodeAnalysis.ElementType.Var: //generic type arg
                         paramnum = MetadataReader.ReadCompressed(source);                        

--- a/tests/CilTools.BytecodeAnalysis.Tests/CilGraphTests_Text.cs
+++ b/tests/CilTools.BytecodeAnalysis.Tests/CilGraphTests_Text.cs
@@ -7,6 +7,8 @@ using System.Reflection;
 using System.Reflection.Emit;
 using CilTools.BytecodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text;
+using System.IO;
 
 namespace CilTools.BytecodeAnalysis.Tests
 {
@@ -64,6 +66,25 @@ namespace CilTools.BytecodeAnalysis.Tests
                 MatchElement.Any, new Literal("\"\""), 
                 MatchElement.Any, new Literal(".param"), MatchElement.Any, new Literal("[2]"),
                 MatchElement.Any, new Literal("int32(0)"), 
+                MatchElement.Any 
+            });
+        }
+
+        [TestMethod]
+        public void Test_CilGraph_Locals()
+        {
+            MethodInfo mi = typeof(SampleMethods).GetMethod("CreatePoint");
+            CilGraph graph = CilGraph.Create(mi);
+
+            StringBuilder sb = new StringBuilder(100);
+            StringWriter wr = new StringWriter(sb);
+            graph.PrintHeader(wr);
+            wr.Flush();
+            string str = sb.ToString();
+
+            AssertThat.IsMatch(str, new MatchElement[] { 
+                MatchElement.Any, new Literal(".locals"),MatchElement.Any, new Literal("("),
+                MatchElement.Any, new Literal("MyPoint"),MatchElement.Any, new Literal(")"),
                 MatchElement.Any 
             });
         }

--- a/tests/CilTools.BytecodeAnalysis.Tests/CilGraphTests_Text.cs
+++ b/tests/CilTools.BytecodeAnalysis.Tests/CilGraphTests_Text.cs
@@ -2,13 +2,13 @@
  * Copyright (c) 2020,  MSDN.WhiteKnight (https://github.com/MSDN-WhiteKnight) 
  * License: BSD 2.0 */
 using System;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
+using System.Text;
 using CilTools.BytecodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Text;
-using System.IO;
 
 namespace CilTools.BytecodeAnalysis.Tests
 {

--- a/tests/CilTools.BytecodeAnalysis.Tests/SampleMethods.cs
+++ b/tests/CilTools.BytecodeAnalysis.Tests/SampleMethods.cs
@@ -126,5 +126,20 @@ namespace CilTools.BytecodeAnalysis.Tests
         {
             Console.WriteLine(str + x.ToString());
         }
+
+        public static MyPoint CreatePoint(float x, float y)
+        {
+            MyPoint p;
+            p = new MyPoint();
+            p.X = x;
+            p.Y = y;
+            return p;
+        }
+    }
+
+    public class MyPoint
+    {
+        public float X { get; set; }
+        public float Y { get; set; }
     }
 }


### PR DESCRIPTION
- Fix bug that prevented correct decoding of TypeDef or TypeSpec tokens during signature parsing
- Guard against null refs in signature parser
- Add test for local variable handling