### PR TITLE
Downgrade Ubuntu version to 18

### DIFF
--- a/.github/workflows/netstd.yml
+++ b/.github/workflows/netstd.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   NetStd-CI:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Fix CI failing with "No usable version of the libssl was found" on Ubuntu 20