### PR TITLE
Improve generic types support

### DIFF
--- a/CilTools.BytecodeAnalysis/CilAnalysis.cs
+++ b/CilTools.BytecodeAnalysis/CilAnalysis.cs
@@ -47,16 +47,25 @@ namespace CilTools.BytecodeAnalysis
             {
                 string prefix;
 
-                if (t.DeclaringMethod == null) prefix = "!";
-                else prefix = "!!";
-
-                if (String.IsNullOrEmpty(t.Name))
+                if (t.DeclaringMethod == null)
                 {
+                    //generic type parameter
+                    prefix = "!";
                     yield return new GenericSyntax(prefix + t.GenericParameterPosition.ToString());
                 }
                 else
                 {
-                    yield return new GenericSyntax(prefix + t.Name);
+                    //generic method parameter
+                    prefix = "!!";
+
+                    if (string.IsNullOrEmpty(t.Name))
+                    {
+                        yield return new GenericSyntax(prefix + t.GenericParameterPosition.ToString());
+                    }
+                    else
+                    {
+                        yield return new GenericSyntax(prefix + t.Name);
+                    }
                 }
             }
             else if (t.IsByRef)

--- a/CilTools.BytecodeAnalysis/Reflection/GenericParamType.cs
+++ b/CilTools.BytecodeAnalysis/Reflection/GenericParamType.cs
@@ -1,5 +1,5 @@
 ﻿/* CilTools.BytecodeAnalysis library 
- * Copyright (c) 2020,  MSDN.WhiteKnight (https://github.com/MSDN-WhiteKnight) 
+ * Copyright (c) 2021,  MSDN.WhiteKnight (https://github.com/MSDN-WhiteKnight) 
  * License: BSD 2.0 */
 using System;
 using System.Collections.Generic;
@@ -22,11 +22,17 @@ namespace CilTools.Reflection
         /// </summary>
         /// <param name="m">Declaring method, if this is a generic method parameter</param>
         /// <param name="index">Generic parameter index</param>
-        public GenericParamType(MethodBase m, int index):this((MemberInfo)m, index, string.Empty)
+        public GenericParamType(MethodBase m, int index):this((MemberInfo)m, index, null)
         {
 
         }
 
+        /// <summary>
+        /// Creates a new instance of the generic parameter
+        /// </summary>
+        /// <param name="declaringMember">Declaring generic type or method of this parameter</param>
+        /// <param name="index">Generic parameter index</param>
+        /// <param name="name">Generic parameter name, or null to fill name automatically</param>
         public static GenericParamType Create(MemberInfo declaringMember, int index, string name)
         {
             return new GenericParamType(declaringMember, index, name);
@@ -39,8 +45,9 @@ namespace CilTools.Reflection
             this._m = declaringMember;
             this._index = index;
 
-            if (!string.IsNullOrEmpty(name))
+            if (name!=null)
             {
+                //if name is provided, use it
                 this._name = name;
                 return;
             }
@@ -49,7 +56,7 @@ namespace CilTools.Reflection
             Type t = null;
             MethodBase m = declaringMember as MethodBase;
 
-            //try load parameter name from declaring method
+            //try load parameter name from declaring member
             if (m != null && m.IsGenericMethod)
             {
                 try

--- a/CilTools.BytecodeAnalysis/Reflection/GenericParamType.cs
+++ b/CilTools.BytecodeAnalysis/Reflection/GenericParamType.cs
@@ -13,7 +13,7 @@ namespace CilTools.Reflection
     /// </summary>
     public class GenericParamType : Type
     {
-        MethodBase _m;
+        MemberInfo _m;
         int _index;
         string _name;
 
@@ -22,15 +22,32 @@ namespace CilTools.Reflection
         /// </summary>
         /// <param name="m">Declaring method, if this is a generic method parameter</param>
         /// <param name="index">Generic parameter index</param>
-        public GenericParamType(MethodBase m, int index)
+        public GenericParamType(MethodBase m, int index):this((MemberInfo)m, index, string.Empty)
+        {
+
+        }
+
+        public static GenericParamType Create(MemberInfo declaringMember, int index, string name)
+        {
+            return new GenericParamType(declaringMember, index, name);
+        }
+        
+        GenericParamType(MemberInfo declaringMember, int index, string name)
         {
             if (index < 0) throw new ArgumentOutOfRangeException("index", "generic parameter index should be non-negative");
 
-            this._m = m;
+            this._m = declaringMember;
             this._index = index;
+
+            if (!string.IsNullOrEmpty(name))
+            {
+                this._name = name;
+                return;
+            }
 
             Type[] args = null;
             Type t = null;
+            MethodBase m = declaringMember as MethodBase;
 
             //try load parameter name from declaring method
             if (m != null && m.IsGenericMethod)
@@ -41,6 +58,20 @@ namespace CilTools.Reflection
                 }
                 catch (NotImplementedException) { }
                 catch (NotSupportedException) { }
+            }
+            else if (declaringMember!=null && declaringMember is Type)
+            {
+                Type declaringType = (Type)declaringMember;
+
+                if (declaringType.IsGenericType)
+                {
+                    try
+                    {
+                        args = declaringType.GetGenericArguments();
+                    }
+                    catch (NotImplementedException) { }
+                    catch (NotSupportedException) { }
+                }
             }
 
             if (args != null && index<args.Length)
@@ -345,7 +376,16 @@ namespace CilTools.Reflection
         {
             get
             {
-                return this._m;
+                return this._m as MethodBase;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override Type DeclaringType
+        {
+            get
+            {
+                return this._m as Type;
             }
         }
 

--- a/CilTools.BytecodeAnalysis/TypeSpec.cs
+++ b/CilTools.BytecodeAnalysis/TypeSpec.cs
@@ -420,7 +420,7 @@ namespace CilTools.BytecodeAnalysis
                         break;
                     case (byte)CilTools.BytecodeAnalysis.ElementType.Var: //generic type arg
                         paramnum = MetadataReader.ReadCompressed(source);
-                        restype = new GenericParamType(null, (int)paramnum);
+                        restype = GenericParamType.Create(member as Type, (int)paramnum, string.Empty);
                         break;
                     case (byte)CilTools.BytecodeAnalysis.ElementType.MVar: //generic method arg
                         paramnum = MetadataReader.ReadCompressed(source);

--- a/CilTools.BytecodeAnalysis/TypeSpec.cs
+++ b/CilTools.BytecodeAnalysis/TypeSpec.cs
@@ -420,7 +420,7 @@ namespace CilTools.BytecodeAnalysis
                         break;
                     case (byte)CilTools.BytecodeAnalysis.ElementType.Var: //generic type arg
                         paramnum = MetadataReader.ReadCompressed(source);
-                        restype = GenericParamType.Create(member as Type, (int)paramnum, string.Empty);
+                        restype = GenericParamType.Create(member as Type, (int)paramnum, null);
                         break;
                     case (byte)CilTools.BytecodeAnalysis.ElementType.MVar: //generic method arg
                         paramnum = MetadataReader.ReadCompressed(source);

--- a/CilTools.Metadata/GenericContext.cs
+++ b/CilTools.Metadata/GenericContext.cs
@@ -1,0 +1,54 @@
+﻿/* CIL Tools 
+ * Copyright (c) 2021,  MSDN.WhiteKnight (https://github.com/MSDN-WhiteKnight) 
+ * License: BSD 2.0 */
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CilTools.Metadata
+{
+    internal struct GenericContext
+    {
+        Type[] typeargs;
+        Type[] methodargs;
+
+        public static readonly GenericContext Empty = default;
+
+        public GenericContext(Type[] genericTypeArguments, Type[] genericMethodArguments)
+        {
+            this.typeargs = genericTypeArguments;
+            this.methodargs = genericMethodArguments;
+        }
+
+        public Type[] GenericTypeArguments
+        {
+            get { return this.typeargs; }
+        }
+
+        public Type[] GenericMethodArguments
+        {
+            get { return this.methodargs; }
+        }
+
+        public Type GetDeclaringType()
+        {
+            if (typeargs != null && typeargs.Length > 0 && methodargs == null)
+            {
+                Type declaringType = null;
+
+                try
+                {
+                    declaringType = typeargs[0].DeclaringType;
+                }
+                catch (NotImplementedException) { }
+                catch (NotSupportedException) { }
+
+                return declaringType;
+            }
+            else
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/CilTools.Metadata/GenericContext.cs
+++ b/CilTools.Metadata/GenericContext.cs
@@ -12,7 +12,7 @@ namespace CilTools.Metadata
         Type[] typeargs;
         Type[] methodargs;
 
-        public static readonly GenericContext Empty = default;
+        public static readonly GenericContext Empty = new GenericContext();
 
         public GenericContext(Type[] genericTypeArguments, Type[] genericMethodArguments)
         {

--- a/CilTools.Metadata/GenericContext.cs
+++ b/CilTools.Metadata/GenericContext.cs
@@ -7,6 +7,9 @@ using System.Text;
 
 namespace CilTools.Metadata
 {
+    /// <summary>
+    /// Represent a set of generic type and method parameters that defines a meaning of generic signature in some context
+    /// </summary>
     internal struct GenericContext
     {
         Type[] typeargs;

--- a/CilTools.Metadata/MetadataAssembly.cs
+++ b/CilTools.Metadata/MetadataAssembly.cs
@@ -272,12 +272,10 @@ namespace CilTools.Metadata
                 if (m != null) return m;
             }
             
-            GenericContext gctx = new GenericContext(genericTypeArguments, genericMethodArguments);
-
             if (eh.Kind == HandleKind.MethodDefinition)
             {
                 MethodDefinition mdef = reader.GetMethodDefinition((MethodDefinitionHandle)eh);
-                m = new MethodDef(mdef, (MethodDefinitionHandle)eh, this, gctx);
+                m = new MethodDef(mdef, (MethodDefinitionHandle)eh, this);
             }
             else if (eh.Kind == HandleKind.MemberReference)
             {
@@ -383,9 +381,7 @@ namespace CilTools.Metadata
                 m = this.CacheGetValue(metadataToken);
                 if (m != null) return m;
             }
-
-            GenericContext gctx = new GenericContext(genericTypeArguments, genericMethodArguments);
-
+            
             if (genericMethodArguments != null && genericMethodArguments.Length > 0)
             {
                 if (genericMethodArguments[0].IsGenericParameter)
@@ -404,7 +400,7 @@ namespace CilTools.Metadata
             if (eh.Kind == HandleKind.MethodDefinition)
             {
                 MethodDefinition mdef = reader.GetMethodDefinition((MethodDefinitionHandle)eh);
-                m = new MethodDef(mdef, (MethodDefinitionHandle)eh, this, gctx);
+                m = new MethodDef(mdef, (MethodDefinitionHandle)eh, this);
             }
             else if (eh.Kind == HandleKind.FieldDefinition)
             {
@@ -515,7 +511,7 @@ namespace CilTools.Metadata
 
             foreach (MethodDefinitionHandle mdefh in reader.MethodDefinitions)
             {
-                yield return this.GetMethodDefinition(mdefh, null, null);
+                yield return this.GetMethodDefinition(mdefh);
             }
 
             foreach (TypeDefinitionHandle ht in reader.TypeDefinitions)
@@ -539,7 +535,7 @@ namespace CilTools.Metadata
 
             foreach (MethodDefinitionHandle mdefh in reader.MethodDefinitions)
             {
-                yield return this.GetMethodDefinition(mdefh, null, null);
+                yield return this.GetMethodDefinition(mdefh);
             }
         }
 
@@ -550,12 +546,11 @@ namespace CilTools.Metadata
             return this.ResolveType(token);
         }
 
-        internal MethodBase GetMethodDefinition(MethodDefinitionHandle hm, 
-            Type[] genericTypeArguments, Type[] genericMethodArguments)
+        internal MethodBase GetMethodDefinition(MethodDefinitionHandle hm)
         {
             int token = this.MetadataReader.GetToken(hm);
 
-            return this.ResolveMethod(token, genericTypeArguments, genericMethodArguments);
+            return this.ResolveMethod(token);
         }
 
         /// <summary>

--- a/CilTools.Metadata/MetadataAssembly.cs
+++ b/CilTools.Metadata/MetadataAssembly.cs
@@ -381,7 +381,7 @@ namespace CilTools.Metadata
                 m = this.CacheGetValue(metadataToken);
                 if (m != null) return m;
             }
-            
+
             if (genericMethodArguments != null && genericMethodArguments.Length > 0)
             {
                 if (genericMethodArguments[0].IsGenericParameter)

--- a/CilTools.Metadata/MethodSpec.cs
+++ b/CilTools.Metadata/MethodSpec.cs
@@ -32,7 +32,7 @@ namespace CilTools.Metadata
             if (eh.Kind == HandleKind.MethodDefinition)
             {
                 MethodDefinition mdef = owner.MetadataReader.GetMethodDefinition((MethodDefinitionHandle)eh);
-                this.definition = new MethodDef(mdef, (MethodDefinitionHandle)eh, owner);
+                this.definition = new MethodDef(mdef, (MethodDefinitionHandle)eh, owner, GenericContext.Empty);
 
                 int rva = mdef.RelativeVirtualAddress;
 

--- a/CilTools.Metadata/MethodSpec.cs
+++ b/CilTools.Metadata/MethodSpec.cs
@@ -32,7 +32,7 @@ namespace CilTools.Metadata
             if (eh.Kind == HandleKind.MethodDefinition)
             {
                 MethodDefinition mdef = owner.MetadataReader.GetMethodDefinition((MethodDefinitionHandle)eh);
-                this.definition = new MethodDef(mdef, (MethodDefinitionHandle)eh, owner, GenericContext.Empty);
+                this.definition = new MethodDef(mdef, (MethodDefinitionHandle)eh, owner);
 
                 int rva = mdef.RelativeVirtualAddress;
 

--- a/CilTools.Metadata/TypeDef.cs
+++ b/CilTools.Metadata/TypeDef.cs
@@ -234,7 +234,7 @@ namespace CilTools.Metadata
         {
             List<MemberInfo> members = new List<MemberInfo>();
             MemberInfo m;
-            
+
             foreach (MethodDefinitionHandle mdefh in this.type.GetMethods())
             {
                 m = this.assembly.GetMethodDefinition(mdefh);

--- a/CilTools.Metadata/TypeDef.cs
+++ b/CilTools.Metadata/TypeDef.cs
@@ -234,16 +234,10 @@ namespace CilTools.Metadata
         {
             List<MemberInfo> members = new List<MemberInfo>();
             MemberInfo m;
-            Type[] targs = null; //generic context
-
-            if (this.IsGenericType)
-            {
-                targs = this.GetGenericArguments();
-            }
-
+            
             foreach (MethodDefinitionHandle mdefh in this.type.GetMethods())
             {
-                m = this.assembly.GetMethodDefinition(mdefh, targs, null);
+                m = this.assembly.GetMethodDefinition(mdefh);
                 if (IsMemberMatching(m, bindingAttr)) members.Add(m);
             }
 

--- a/CilTools.Metadata/TypeDef.cs
+++ b/CilTools.Metadata/TypeDef.cs
@@ -234,10 +234,16 @@ namespace CilTools.Metadata
         {
             List<MemberInfo> members = new List<MemberInfo>();
             MemberInfo m;
+            Type[] targs = null; //generic context
+
+            if (this.IsGenericType)
+            {
+                targs = this.GetGenericArguments();
+            }
 
             foreach (MethodDefinitionHandle mdefh in this.type.GetMethods())
             {
-                m = this.assembly.GetMethodDefinition(mdefh);
+                m = this.assembly.GetMethodDefinition(mdefh, targs, null);
                 if (IsMemberMatching(m, bindingAttr)) members.Add(m);
             }
 
@@ -448,9 +454,9 @@ namespace CilTools.Metadata
                 StringHandle sh = gp.Name;
 
                 if (!sh.IsNil)
-                    ret[i] = new GenericParamType(null, gp.Index, assembly.MetadataReader.GetString(sh));
+                    ret[i] = GenericParamType.Create(this, gp.Index, assembly.MetadataReader.GetString(sh));
                 else
-                    ret[i] = new GenericParamType(null, gp.Index);
+                    ret[i] = GenericParamType.Create(this, gp.Index, string.Empty);
             }
 
             return ret;

--- a/tests/CilTools.BytecodeAnalysis.Tests/ReflectionTests.cs
+++ b/tests/CilTools.BytecodeAnalysis.Tests/ReflectionTests.cs
@@ -2,7 +2,9 @@
  * Copyright (c) 2021,  MSDN.WhiteKnight (https://github.com/MSDN-WhiteKnight) 
  * License: BSD 2.0 */
 using System;
+using System.Collections.Generic;
 using System.Reflection;
+using CilTools.Reflection;
 using CilTools.Tests.Common;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -30,6 +32,22 @@ namespace CilTools.BytecodeAnalysis.Tests
         public void Test_TypedReferenceParam(MethodBase mi)
         {
             ReflectionTestsCore.Test_TypedReferenceParam(mi);
+        }
+
+        [TestMethod]        
+        public void Test_GenericParamType()
+        {
+            GenericParamType tParam = GenericParamType.Create(typeof(IList<>), 0, null);
+            Assert.IsTrue(tParam.IsGenericParameter);
+            Assert.AreEqual("T", tParam.Name);
+            Assert.AreEqual("IList`1", tParam.DeclaringType.Name);
+            Assert.IsNull(tParam.DeclaringMethod);
+
+            tParam = GenericParamType.Create(typeof(IList<>), 0, "T");
+            Assert.IsTrue(tParam.IsGenericParameter);
+            Assert.AreEqual("T", tParam.Name);
+            Assert.AreEqual("IList`1", tParam.DeclaringType.Name);
+            Assert.IsNull(tParam.DeclaringMethod);
         }
     }
 }

--- a/tests/CilTools.Metadata.Tests/CilTools.Metadata.Tests.csproj
+++ b/tests/CilTools.Metadata.Tests/CilTools.Metadata.Tests.csproj
@@ -64,6 +64,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CilGraphTests_Text.cs" />
+    <Compile Include="GenericsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReflectionTests.cs" />
     <Compile Include="MemoryImageTests.cs" />

--- a/tests/CilTools.Metadata.Tests/GenericsTests.cs
+++ b/tests/CilTools.Metadata.Tests/GenericsTests.cs
@@ -1,0 +1,54 @@
+﻿/* CilTools.Metadata tests
+ * Copyright (c) 2021,  MSDN.WhiteKnight (https://github.com/MSDN-WhiteKnight) 
+ * License: BSD 2.0 */
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using CilTools.Reflection;
+using CilTools.Tests.Common;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CilTools.Metadata.Tests
+{
+    [TestClass]
+    public class GenericsTests
+    {
+        const string typename = "System.Collections.Generic.IList`1";
+
+        [TestMethod]
+        public void Test_GenericTypeParams_Name()
+        {
+            AssemblyReader reader = new AssemblyReader();
+
+            using (reader)
+            {
+                Assembly ass = reader.LoadFrom(typeof(IList<>).Assembly.Location);
+                Type t = ass.GetType(typename);
+                CustomMethod mi = t.GetMember("IndexOf")[0] as CustomMethod;
+                ParameterInfo[] pars = mi.GetParameters();
+                Type parameterType = pars[0].ParameterType;
+                Assert.IsTrue(parameterType.IsGenericParameter);
+                Assert.AreEqual("T", parameterType.Name);
+            }
+        }
+
+        [TestMethod]
+        public void Test_GenericTypeParams_DeclaringType()
+        {
+            AssemblyReader reader = new AssemblyReader();
+
+            using (reader)
+            {
+                Assembly ass = reader.LoadFrom(typeof(IList<>).Assembly.Location);
+                Type t = ass.GetType(typename);
+                CustomMethod mi = t.GetMember("IndexOf")[0] as CustomMethod;
+                ParameterInfo[] pars = mi.GetParameters();
+                Type parameterType = pars[0].ParameterType;
+                Assert.IsTrue(parameterType.IsGenericParameter);
+                Assert.AreEqual(typename, parameterType.DeclaringType.FullName);
+                Assert.IsNull(parameterType.DeclaringMethod);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Pass generic context to GenericParamType for methods in generic types. This enables outputting generic parameter name when decompiling such methods.