### PR TITLE
Add Export type to file

### DIFF
--- a/CilTools.BytecodeAnalysis/Reflection/ReflectionUtils.cs
+++ b/CilTools.BytecodeAnalysis/Reflection/ReflectionUtils.cs
@@ -15,7 +15,7 @@ namespace CilTools.Reflection
             get { return BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic; }
         }
 
-        static bool IsExpectedException(Exception ex)
+        public static bool IsExpectedException(Exception ex)
         {
             //check expected exception types that can pop up due to reflection APIs being not 
             //implemented on custom subclasses 

--- a/CilTools.BytecodeAnalysis/Syntax/DirectiveSyntax.cs
+++ b/CilTools.BytecodeAnalysis/Syntax/DirectiveSyntax.cs
@@ -114,7 +114,7 @@ namespace CilTools.Syntax
             }
         }
 
-        internal static DirectiveSyntax FromMethodSignature(MethodBase m)
+        internal static DirectiveSyntax FromMethodSignature(MethodBase m, string lead)
         {
             ICustomMethod cm = (ICustomMethod)m;
             ParameterInfo[] pars = m.GetParameters();
@@ -258,10 +258,10 @@ namespace CilTools.Syntax
 
             for (int i = 0; i < pars.Length; i++)
             {
-                if (i >= 1) inner.Add(new PunctuationSyntax(String.Empty, ",", " "+ Environment.NewLine));
+                if (i >= 1) inner.Add(new PunctuationSyntax(string.Empty, ",", " " + Environment.NewLine));
                 else inner.Add(new GenericSyntax(Environment.NewLine));
 
-                inner.Add(new GenericSyntax("    "));
+                inner.Add(new GenericSyntax(lead + "    "));
 
                 if (pars[i].IsOptional) inner.Add(new GenericSyntax("[opt] "));
 
@@ -275,7 +275,7 @@ namespace CilTools.Syntax
                 inner.Add(new IdentifierSyntax(" ", parname, String.Empty,false, pars[i]));
             }
 
-            if (pars.Length > 0) inner.Add(new GenericSyntax(Environment.NewLine));
+            if (pars.Length > 0) inner.Add(new GenericSyntax(Environment.NewLine + lead));
             inner.Add(new PunctuationSyntax(String.Empty, ")", String.Empty));
 
             //ECMA-335 II.15.4.3 - Implementation attributes of methods
@@ -336,7 +336,7 @@ namespace CilTools.Syntax
 
             inner.Add(new GenericSyntax(Environment.NewLine));
 
-            return new DirectiveSyntax("", "method", inner.ToArray());
+            return new DirectiveSyntax(lead, "method", inner.ToArray());
         }
     }
 }

--- a/CilTools.BytecodeAnalysis/Syntax/SyntaxNode.cs
+++ b/CilTools.BytecodeAnalysis/Syntax/SyntaxNode.cs
@@ -289,13 +289,31 @@ namespace CilTools.Syntax
         /// </summary>
         /// <param name="t">Type to get definition syntax</param>
         /// <returns>The collection of syntax nodes that make up type definition syntax</returns>
+        /// <exception cref="ArgumentNullException">The specified type is null</exception>
         public static IEnumerable<SyntaxNode> GetTypeDefSyntax(Type t)
         {
+            if (t == null) throw new ArgumentNullException("t");
+
             return GetTypeDefSyntaxImpl(t, false, DisassemblerParams.Default, 0);
         }
 
+        /// <summary>
+        /// Gets the CIL assembler syntax for the definition of the specified type with specified disassembler parameters
+        /// </summary>
+        /// <param name="t">Type to get definition syntax</param>
+        /// <param name="full">
+        /// <c>true</c> to return full syntax (including method defnitions and nested types), <c>false</c> to return
+        /// short syntax
+        /// </param>
+        /// <param name="disassemblerParams">
+        /// Object that specifies additional options for the disassembling operation
+        /// </param>
+        /// <returns>The collection of syntax nodes that make up type definition syntax</returns>
+        /// <exception cref="ArgumentNullException">The specified type is null</exception>
         public static IEnumerable<SyntaxNode> GetTypeDefSyntax(Type t, bool full, DisassemblerParams disassemblerParams)
         {
+            if (t == null) throw new ArgumentNullException("t");
+            
             return GetTypeDefSyntaxImpl(t, full, disassemblerParams, 0);
         }
 

--- a/CilTools.BytecodeAnalysis/Syntax/SyntaxNode.cs
+++ b/CilTools.BytecodeAnalysis/Syntax/SyntaxNode.cs
@@ -230,7 +230,12 @@ namespace CilTools.Syntax
             return content;
         }
 
-        internal static SyntaxNode[] GetDefaultsSyntax(MethodBase m)
+        internal static string GetIndentString(int c)
+        {
+            return "".PadLeft(c, ' ');
+        }
+
+        internal static SyntaxNode[] GetDefaultsSyntax(MethodBase m, int startIndent)
         {
             ParameterInfo[] pars = m.GetParameters();
             List<SyntaxNode> ret = new List<SyntaxNode>(pars.Length);
@@ -252,7 +257,7 @@ namespace CilTools.Syntax
 
                     string content = sb.ToString();
                     DirectiveSyntax dir = new DirectiveSyntax(
-                        " ", "param", new SyntaxNode[] { new GenericSyntax(content) }
+                        GetIndentString(startIndent+1), "param", new SyntaxNode[] { new GenericSyntax(content) }
                         );
                     ret.Add(dir);
                 }
@@ -285,6 +290,17 @@ namespace CilTools.Syntax
         /// <param name="t">Type to get definition syntax</param>
         /// <returns>The collection of syntax nodes that make up type definition syntax</returns>
         public static IEnumerable<SyntaxNode> GetTypeDefSyntax(Type t)
+        {
+            return GetTypeDefSyntaxImpl(t, false, DisassemblerParams.Default, 0);
+        }
+
+        public static IEnumerable<SyntaxNode> GetTypeDefSyntax(Type t, bool full, DisassemblerParams disassemblerParams)
+        {
+            return GetTypeDefSyntaxImpl(t, full, disassemblerParams, 0);
+        }
+
+        internal static IEnumerable<SyntaxNode> GetTypeDefSyntaxImpl(Type t, bool full, 
+            DisassemblerParams disassemblerParams, int startIndent)
         {
             List<SyntaxNode> content = new List<SyntaxNode>(10);
 
@@ -424,7 +440,7 @@ namespace CilTools.Syntax
             //base type
             if (!t.IsInterface && t.BaseType!=null)
             {
-                content.Add(new KeywordSyntax(String.Empty, "extends", " ", KeywordKind.Other));
+                content.Add(new KeywordSyntax(GetIndentString(startIndent), "extends", " ", KeywordKind.Other));
 
                 try
                 {
@@ -456,7 +472,7 @@ namespace CilTools.Syntax
 
             if (interfaces != null && interfaces.Length > 0)
             {
-                content.Add(new KeywordSyntax(String.Empty, "implements", " ", KeywordKind.Other));
+                content.Add(new KeywordSyntax(GetIndentString(startIndent), "implements", " ", KeywordKind.Other));
 
                 for (int i = 0; i < interfaces.Length; i++)
                 {
@@ -473,7 +489,7 @@ namespace CilTools.Syntax
                 content.Add(new GenericSyntax(Environment.NewLine));
             }
 
-            DirectiveSyntax header = new DirectiveSyntax( String.Empty, "class",content.ToArray());
+            DirectiveSyntax header = new DirectiveSyntax(GetIndentString(startIndent), "class", content.ToArray());
             yield return header;
             
             //body
@@ -482,20 +498,21 @@ namespace CilTools.Syntax
             //custom attributes
             try
             {
-                SyntaxNode[] arr = SyntaxNode.GetAttributesSyntax(t, 1);
+                SyntaxNode[] arr = SyntaxNode.GetAttributesSyntax(t, startIndent + 1);
 
                 for (int i = 0; i < arr.Length; i++)
                 {
                     content.Add(arr[i]);
                 }
             }
-            catch (InvalidOperationException)
+            catch (Exception ex)
             {
-                content.Add(CommentSyntax.Create(" ", "NOTE: Custom attributes are not shown.", null, false));
-            }
-            catch (NotImplementedException)
-            {
-                content.Add(CommentSyntax.Create(" ", "NOTE: Custom attributes are not shown.", null, false));
+                if (ReflectionUtils.IsExpectedException(ex))
+                {
+                    content.Add(CommentSyntax.Create(GetIndentString(startIndent + 1),
+                        "NOTE: Custom attributes are not shown.", null, false));
+                }
+                else throw;
             }
 
             content.Add(new GenericSyntax(Environment.NewLine));
@@ -584,7 +601,7 @@ namespace CilTools.Syntax
 
                 inner.Add(new GenericSyntax(Environment.NewLine));
 
-                DirectiveSyntax field = new DirectiveSyntax(" ", "field", inner.ToArray());
+                DirectiveSyntax field = new DirectiveSyntax(GetIndentString(startIndent + 1), "field", inner.ToArray());
                 content.Add(field);
             }
 
@@ -597,15 +614,15 @@ namespace CilTools.Syntax
             {
                 props = t.GetProperties(allMembers);
             }
-            catch (NotSupportedException)
+            catch (Exception ex)
             {
-                props = new PropertyInfo[0];
-                content.Add(CommentSyntax.Create(" ", "NOTE: Properties are not shown." + Environment.NewLine, null, false));
-            }
-            catch (NotImplementedException)
-            {
-                props = new PropertyInfo[0];
-                content.Add(CommentSyntax.Create(" ", "NOTE: Properties are not shown." + Environment.NewLine, null, false));
+                if (ReflectionUtils.IsExpectedException(ex))
+                {
+                    props = new PropertyInfo[0];
+                    content.Add(CommentSyntax.Create(GetIndentString(startIndent + 1),
+                        "NOTE: Properties are not shown." + Environment.NewLine, null, false));
+                }
+                else throw;
             }
 
             for (int i = 0; i < props.Length; i++)
@@ -657,32 +674,36 @@ namespace CilTools.Syntax
                 }
                 
                 inner.Add(new PunctuationSyntax(string.Empty, ")", Environment.NewLine));
-                inner.Add(new PunctuationSyntax(" ", "{", Environment.NewLine));
+                inner.Add(new PunctuationSyntax(GetIndentString(startIndent + 1), "{", Environment.NewLine));
 
                 //property custom attributes
                 try
                 {
-                    SyntaxNode[] arr = GetAttributesSyntax(props[i], 2);
+                    SyntaxNode[] arr = GetAttributesSyntax(props[i], startIndent + 2);
 
                     for (int j = 0; j < arr.Length; j++)
                     {
                         inner.Add(arr[j]);
                     }
                 }
-                catch (InvalidOperationException)
+                catch (Exception ex)
                 {
-                    inner.Add(CommentSyntax.Create("  ", "NOTE: Custom attributes are not shown.", null, false));
-                }
-                catch (NotImplementedException)
-                {
-                    inner.Add(CommentSyntax.Create("  ", "NOTE: Custom attributes are not shown.", null, false));
+                    if (ReflectionUtils.IsExpectedException(ex))
+                    {
+                        inner.Add(CommentSyntax.Create(GetIndentString(startIndent + 2),
+                            "NOTE: Custom attributes are not shown.", null, false));
+                    }
+                    else throw;
                 }
                 
                 //property methods
                 if (getter != null) 
                 {
                     MemberRefSyntax mref = CilAnalysis.GetMethodRefSyntax(getter, false);
-                    DirectiveSyntax dirGet = new DirectiveSyntax("  ", "get",new SyntaxNode[] { mref });
+
+                    DirectiveSyntax dirGet = new DirectiveSyntax(GetIndentString(startIndent + 2), 
+                        "get",new SyntaxNode[] { mref });
+
                     inner.Add(dirGet);
                     inner.Add(new GenericSyntax(Environment.NewLine));
                 }
@@ -690,21 +711,119 @@ namespace CilTools.Syntax
                 if (setter != null)
                 {
                     MemberRefSyntax mref = CilAnalysis.GetMethodRefSyntax(setter, false);
-                    DirectiveSyntax dirSet = new DirectiveSyntax("  ", "set", new SyntaxNode[] { mref });
+
+                    DirectiveSyntax dirSet = new DirectiveSyntax(GetIndentString(startIndent + 2), 
+                        "set", new SyntaxNode[] { mref });
+
                     inner.Add(dirSet);
                     inner.Add(new GenericSyntax(Environment.NewLine));
                 }
 
-                inner.Add(new PunctuationSyntax(" ", "}", Environment.NewLine + Environment.NewLine));
-                DirectiveSyntax dirProp = new DirectiveSyntax(" ", "property", inner.ToArray());
+                inner.Add(new PunctuationSyntax(GetIndentString(startIndent + 1), "}", Environment.NewLine + Environment.NewLine));
+                DirectiveSyntax dirProp = new DirectiveSyntax(GetIndentString(startIndent + 1), "property", inner.ToArray());
                 content.Add(dirProp);
             }
 
-            //add comment to indicate that not all members are listed here
-            content.Add(CommentSyntax.Create(" ", "...", null, false));
-            content.Add(new GenericSyntax(Environment.NewLine));
+            if (full)
+            {
+                //constructors
+                ConstructorInfo[] constructors;
 
-            BlockSyntax body = new BlockSyntax(String.Empty, SyntaxNode.EmptyArray, content.ToArray());
+                try
+                {
+                    constructors = t.GetConstructors(allMembers);
+                }
+                catch (Exception ex)
+                {
+                    if (ReflectionUtils.IsExpectedException(ex))
+                    {
+                        content.Add(CommentSyntax.Create(GetIndentString(startIndent + 1),
+                            "NOTE: Constructors are not shown.", null, false));
+                        constructors = new ConstructorInfo[0];
+                    }
+                    else throw;
+                }
+
+                for (int i = 0; i < constructors.Length; i++)
+                {
+                    CilGraph gr = CilGraph.Create(constructors[i]);
+                    MethodDefSyntax mds = gr.ToSyntaxTreeImpl(disassemblerParams, startIndent + 1);
+                    content.Add(mds);
+                    content.Add(new GenericSyntax(Environment.NewLine));
+                }
+
+                //methods
+                MethodInfo[] methods;
+
+                try
+                {
+                    methods = t.GetMethods(allMembers);
+                }
+                catch (Exception ex)
+                {
+                    if (ReflectionUtils.IsExpectedException(ex))
+                    {
+                        content.Add(CommentSyntax.Create(GetIndentString(startIndent + 1),
+                            "NOTE: Methods are not shown.", null, false));
+                        methods = new MethodInfo[0];
+                    }
+                    else throw;
+                }
+
+                for (int i = 0; i < methods.Length; i++)
+                {
+                    CilGraph gr = CilGraph.Create(methods[i]);
+                    MethodDefSyntax mds = gr.ToSyntaxTreeImpl(disassemblerParams, startIndent + 1);
+                    content.Add(mds);
+                    content.Add(new GenericSyntax(Environment.NewLine));
+                }
+
+                //nested types
+                Type[] types = new Type[0];
+
+                if (startIndent > 20)
+                {
+                    content.Add(CommentSyntax.Create(string.Empty,
+                        "ERROR: Indentation is too deep to show nested types!", null, false));
+                }
+                else
+                {
+                    try
+                    {
+                        types = t.GetNestedTypes(allMembers);
+                    }
+                    catch (Exception ex)
+                    {
+                        if (ReflectionUtils.IsExpectedException(ex))
+                        {
+                            content.Add(CommentSyntax.Create(GetIndentString(startIndent + 1),
+                                "NOTE: Nested types are not shown.", null, false));
+                        }
+                        else throw;
+                    }
+                }
+
+                for (int i = 0; i < types.Length; i++)
+                {
+                    IEnumerable<SyntaxNode> typeNodes = GetTypeDefSyntaxImpl(types[i], 
+                        true, disassemblerParams, startIndent + 1);
+
+                    foreach (SyntaxNode node in typeNodes)
+                    {
+                        content.Add(node);
+                    }
+
+                    content.Add(new GenericSyntax(Environment.NewLine));
+                }
+            }
+            else
+            {
+                //add comment to indicate that not all members are listed here
+                content.Add(CommentSyntax.Create(GetIndentString(startIndent + 1), "...", null, false));
+                content.Add(new GenericSyntax(Environment.NewLine));
+            }
+
+            BlockSyntax body = new BlockSyntax(GetIndentString(startIndent), SyntaxNode.EmptyArray, content.ToArray());
 
             for (int i = 0; i < body._children.Count; i++) body._children[i]._parent = body;
 

--- a/CilView.Core/Syntax/SyntaxWriter.cs
+++ b/CilView.Core/Syntax/SyntaxWriter.cs
@@ -1,0 +1,47 @@
+﻿/* CIL Tools 
+ * Copyright (c) 2022,  MSDN.WhiteKnight (https://github.com/MSDN-WhiteKnight) 
+ * License: BSD 2.0 */
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using CilTools.Syntax;
+
+namespace CilView.Core.Syntax
+{
+    public static class SyntaxWriter
+    {
+        static async Task WriteSyntaxAsync(IEnumerable<SyntaxNode> nodes, TextWriter target)
+        {
+            foreach (SyntaxNode node in nodes)
+            {
+                string s = node.ToString();
+                await target.WriteAsync(s);
+            }
+        }
+
+        static async Task WriteHeaderAsync(TextWriter target)
+        {
+            Version ver = typeof(SyntaxWriter).Assembly.GetName().Version;
+            await target.WriteLineAsync("// CIL Tools " + ver.ToString());
+            await target.WriteLineAsync("// https://github.com/MSDN-WhiteKnight/CilTools");
+            await target.WriteLineAsync();
+        }
+
+        public static async Task DisassembleTypeAsync(Type t, DisassemblerParams pars, TextWriter target)
+        {
+            await WriteHeaderAsync(target);
+            IEnumerable<SyntaxNode> nodes = SyntaxNode.GetTypeDefSyntax(t, true, pars);
+            await WriteSyntaxAsync(nodes, target);
+            await target.FlushAsync();
+        }
+
+        public static async Task WriteContentAsync(string content, TextWriter target)
+        {
+            await WriteHeaderAsync(target);
+            await target.WriteAsync(content);
+            await target.FlushAsync();
+        }
+    }
+}

--- a/CilView/MainWindow.xaml
+++ b/CilView/MainWindow.xaml
@@ -11,7 +11,8 @@
                 <MenuItem x:Name="miOpenBCL" Header="Open BCL assembly" Click="miOpenBCL_Click"/>
                 <MenuItem x:Name="miOpenCode" Header="Open code" Click="miOpenCode_Click" />
                 <Separator/>
-                <MenuItem x:Name="miExportMethod" Header="Export to file" Click="miExportMethod_Click"/>   
+                <MenuItem x:Name="miExportMethod" Header="Export to file" Click="miExportMethod_Click"/>
+                <MenuItem x:Name="miExportType" Header="Export type to file" Click="miExportType_Click"/>
                 <Separator/>
                 <MenuItem x:Name="miExit" Header="Exit" Click="miExit_Click"/>
             </MenuItem>

--- a/CilView/MainWindow.xaml.cs
+++ b/CilView/MainWindow.xaml.cs
@@ -14,6 +14,7 @@ using CilTools.Runtime;
 using CilView.Build;
 using CilView.Common;
 using CilView.Core;
+using CilView.Core.Syntax;
 using CilView.Exceptions;
 using CilView.SourceCode;
 using CilView.UI.Dialogs;
@@ -473,7 +474,41 @@ typeof(MainWindow).Assembly.GetName().Version.ToString());
 
                     using (wr)
                     {
-                        await wr.WriteAsync(txt);
+                        await SyntaxWriter.WriteContentAsync(txt, wr);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                ErrorHandler.Current.Error(ex);
+            }
+        }
+
+        private async void miExportType_Click(object sender, RoutedEventArgs e)
+        {
+            Type t = cilbrowser.GetCurrentType();
+
+            if (t == null)
+            {
+                MessageBox.Show(this, "No content to export. Open type first to export its code", "Error");
+                return;
+            }
+
+            try
+            {
+                SaveFileDialog dlg = new SaveFileDialog();
+                dlg.RestoreDirectory = true;
+                dlg.DefaultExt = ".il";
+                dlg.Filter = "CIL Assembler source (*.il)|*.il|All files|*";
+                dlg.FileName = t.Name + ".il";
+
+                if (dlg.ShowDialog(this) == true)
+                {
+                    StreamWriter wr = new StreamWriter(dlg.FileName, false, Encoding.UTF8);
+
+                    using (wr)
+                    {
+                        await SyntaxWriter.DisassembleTypeAsync(t, CilVisualization.CurrentDisassemblerParams, wr);
                     }
                 }
             }

--- a/tests/CilTools.BytecodeAnalysis.Tests/CilTools.BytecodeAnalysis.Tests.csproj
+++ b/tests/CilTools.BytecodeAnalysis.Tests/CilTools.BytecodeAnalysis.Tests.csproj
@@ -38,7 +38,8 @@
     <Compile Include="Signatures\TypeSpecTests.cs" />    
     <Compile Include="SourceCode\SourceCodeProviderTests.cs" />    
     <Compile Include="SyntaxTests.cs" />    
-    <Compile Include="Syntax\SyntaxFactoryTests.cs" />
+    <Compile Include="Syntax\SyntaxFactoryTests.cs" />    
+    <Compile Include="Syntax\SyntaxNodeTests.cs" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)'=='net45'">

--- a/tests/CilTools.BytecodeAnalysis.Tests/Syntax/SyntaxNodeTests.cs
+++ b/tests/CilTools.BytecodeAnalysis.Tests/Syntax/SyntaxNodeTests.cs
@@ -1,0 +1,28 @@
+﻿/* CIL Tools
+ * Copyright (c) 2022,  MSDN.WhiteKnight (https://github.com/MSDN-WhiteKnight) 
+ * License: BSD 2.0 */
+using System;
+using System.Collections.Generic;
+using System.Text;
+using CilTools.Syntax;
+using CilTools.Tests.Common;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CilTools.BytecodeAnalysis.Tests.Syntax
+{
+    [TestClass]
+    public class SyntaxNodeTests
+    {
+        [TestMethod]
+        public void Test_GetTypeDefSyntax_Short()
+        {
+            SyntaxTestsCore.Test_GetTypeDefSyntax_Short(typeof(SampleMethods));
+        }
+
+        [TestMethod]
+        public void Test_GetTypeDefSyntax_Full()
+        {
+            SyntaxTestsCore.Test_GetTypeDefSyntax_Full(typeof(DisassemblerSampleType));
+        }
+    }
+}

--- a/tests/CilTools.Metadata.Tests/TypeDefTests.cs
+++ b/tests/CilTools.Metadata.Tests/TypeDefTests.cs
@@ -498,5 +498,31 @@ namespace CilTools.Metadata.Tests
                 Assert.IsTrue(c.IsStatic);
             }
         }
+
+        [TestMethod]
+        public void Test_GetTypeDefSyntax_Short()
+        {
+            AssemblyReader reader = new AssemblyReader();
+
+            using (reader)
+            {
+                Assembly ass = reader.LoadFrom(typeof(SampleMethods).Assembly.Location);
+                Type t = ass.GetType(typeof(SampleMethods).FullName);
+                SyntaxTestsCore.Test_GetTypeDefSyntax_Short(t);
+            }
+        }
+
+        [TestMethod]
+        public void Test_GetTypeDefSyntax_Full()
+        {
+            AssemblyReader reader = new AssemblyReader();
+
+            using (reader)
+            {
+                Assembly ass = reader.LoadFrom(typeof(DisassemblerSampleType).Assembly.Location);
+                Type t = ass.GetType(typeof(DisassemblerSampleType).FullName);
+                SyntaxTestsCore.Test_GetTypeDefSyntax_Full(t);
+            }
+        }
     }
 }

--- a/tests/CilTools.Tests.Common/DisassemblerSampleType.cs
+++ b/tests/CilTools.Tests.Common/DisassemblerSampleType.cs
@@ -1,0 +1,19 @@
+﻿/* CIL Tools
+ * Copyright (c) 2022,  MSDN.WhiteKnight (https://github.com/MSDN-WhiteKnight) 
+ * License: BSD 2.0 */
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CilTools.Tests.Common
+{
+    public class DisassemblerSampleType
+    {
+        public static int x;
+
+        public static void Test()
+        {
+            Console.WriteLine("Hello, World");
+        }
+    }
+}

--- a/tests/CilTools.Tests.Common/SyntaxTestsCore.cs
+++ b/tests/CilTools.Tests.Common/SyntaxTestsCore.cs
@@ -2,6 +2,7 @@
  * Copyright (c) 2021,  MSDN.WhiteKnight (https://github.com/MSDN-WhiteKnight) 
  * License: BSD 2.0 */
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using CilTools.BytecodeAnalysis;
 using CilTools.Reflection;
@@ -51,6 +52,39 @@ namespace CilTools.Tests.Common
                 "void", Text.Any,
                 "'method'", Text.Any,
                 "cil", Text.Any, "managed", Text.Any,                
+            });
+        }
+
+        public static void Test_GetTypeDefSyntax_Short(Type t)
+        {
+            IEnumerable<SyntaxNode> nodes = SyntaxNode.GetTypeDefSyntax(t);
+            string s = Utils.SyntaxToString(nodes);
+
+            AssertThat.IsMatch(s, new Text[] {
+                ".class", Text.Any,"public", Text.Any,"abstract", Text.Any,"CilTools.Tests.Common.SampleMethods", Text.Any,
+                "{", Text.Any,
+                ".field", Text.Any,"public", Text.Any,"static", Text.Any,"int32", Text.Any,"Foo", Text.Any,
+                ".field", Text.Any,"public", Text.Any,"static", Text.Any,"int32", Text.Any,"counter", Text.Any,
+                ".field", Text.Any,"public", Text.Any,"static", Text.Any,"int32", Text.Any,"f", Text.Any,
+                "}", Text.Any
+            });
+
+            Assert.IsFalse(s.Contains(".method"));
+        }
+
+        public static void Test_GetTypeDefSyntax_Full(Type t)
+        {
+            IEnumerable<SyntaxNode> nodes = SyntaxNode.GetTypeDefSyntax(t, true, new DisassemblerParams());
+            string s = Utils.SyntaxToString(nodes);
+
+            AssertThat.IsMatch(s, new Text[] {
+                ".class", Text.Any,"public", Text.Any,"CilTools.Tests.Common.DisassemblerSampleType", Text.Any,
+                "{", Text.Any,
+                ".field", Text.Any,"public", Text.Any,"static", Text.Any,"int32", Text.Any,"x", Text.Any,
+                ".method", Text.Any,"static", Text.Any,"Test()", Text.Any,"cil", Text.Any,"managed", Text.Any,
+                "{", Text.Any,".maxstack", Text.Any,"8", Text.Any,"ldstr", Text.Any,"\"Hello, World\"", Text.Any,
+                "call", Text.Any, "System.Console::WriteLine", Text.Any,"ret", Text.Any,"}", Text.Any,
+                "}", Text.Any
             });
         }
     }


### PR DESCRIPTION
- Add SyntaxNode.GetTypeDefSyntax overload that supports exporting full type syntax tree
- Add "Export type to file" menu command in CIL View