### PR TITLE
Disable formatted view for large .il files

### DIFF
--- a/CilView/UI.Controls/CilBrowserPage.xaml.cs
+++ b/CilView/UI.Controls/CilBrowserPage.xaml.cs
@@ -92,6 +92,7 @@ namespace CilView.UI.Controls
             {
                 TextBlock txt = new TextBlock();
                 txt.Text = "[Error: Formatted view is not supported for files larger then 1 MB]";
+                txt.Padding = new Thickness(5);
                 gridContent.Children.Add(txt);
             }
             

--- a/CilView/UI.Controls/CilBrowserPage.xaml.cs
+++ b/CilView/UI.Controls/CilBrowserPage.xaml.cs
@@ -83,7 +83,18 @@ namespace CilView.UI.Controls
             
             this.tbMainContent.Text = contentText;
             gridContent.Children.Clear();
-            gridContent.Children.Add(CilVisualization.VisualizeSourceText(contentText));
+            
+            if (contentText.Length < 1024*1024)
+            {
+                gridContent.Children.Add(CilVisualization.VisualizeSourceText(contentText));
+            }
+            else
+            {
+                TextBlock txt = new TextBlock();
+                txt2.Text = "[Error: Formatted view is not supported for files larger then 1 MB]";
+                gridContent.Children.Add(txt);
+            }
+            
             this.tbCurrLocation.Text = filename;
         }
 

--- a/CilView/UI.Controls/CilBrowserPage.xaml.cs
+++ b/CilView/UI.Controls/CilBrowserPage.xaml.cs
@@ -91,7 +91,7 @@ namespace CilView.UI.Controls
             else
             {
                 TextBlock txt = new TextBlock();
-                txt2.Text = "[Error: Formatted view is not supported for files larger then 1 MB]";
+                txt.Text = "[Error: Formatted view is not supported for files larger then 1 MB]";
                 gridContent.Children.Add(txt);
             }
             

--- a/tests/CilTools.Tests.Common/Utils.cs
+++ b/tests/CilTools.Tests.Common/Utils.cs
@@ -46,5 +46,39 @@ namespace CilTools.Tests.Common
             return "Release";
 #endif
         }
+
+        static string[] words = {
+            "Test","Foo","Bar","Buzz","Frobby","Bobby","Hello","Alice","Bob","Lee","Miroslav","Nicolas","Peter"
+        };
+
+        public static void GenerateFakeIL(int repeats, TextWriter target)
+        {
+            Random rnd = new Random();
+
+            for (int i = 0; i < repeats; i++)
+            {
+                int nWord = rnd.Next(words.Length);
+                int nNumber = rnd.Next();
+
+                string name = words[nWord] + nNumber.ToString();
+                string str = ".method public static void " + name + "() cil managed { } ";
+                target.Write(str);
+
+                nWord = rnd.Next(words.Length);
+                nNumber = rnd.Next();
+                str = "//" + words[nWord] + nNumber.ToString();
+                target.WriteLine(str);
+            }
+
+            target.Flush();
+        }
+
+        public static string GenerateFakeIL(int repeats)
+        {
+            StringBuilder sb = new StringBuilder(5000);
+            StringWriter wr = new StringWriter(sb);
+            GenerateFakeIL(repeats, wr);
+            return sb.ToString();
+        }
     }
 }

--- a/tests/CilTools.Tests.Common/Utils.cs
+++ b/tests/CilTools.Tests.Common/Utils.cs
@@ -47,12 +47,12 @@ namespace CilTools.Tests.Common
 #endif
         }
 
-        static string[] words = {
-            "Test","Foo","Bar","Buzz","Frobby","Bobby","Hello","Alice","Bob","Lee","Miroslav","Nicolas","Peter"
-        };
-
         public static void GenerateFakeIL(int repeats, TextWriter target)
         {
+            string[] words = {
+                "Test","Foo","Bar","Buzz","Frobby","Bobby","Hello","Alice","Bob","Lee","Miroslav","Nicolas","Peter"
+            };
+
             Random rnd = new Random();
 
             for (int i = 0; i < repeats; i++)

--- a/tests/CilView.Tests/SyntaxReaderTests.cs
+++ b/tests/CilView.Tests/SyntaxReaderTests.cs
@@ -11,6 +11,43 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace CilView.Tests
 {
+    public static class FakeILGenerator
+    {
+        static string[] words = {
+            "Test","Foo","Bar","Buzz","Frobby","Bobby","Hello","Alice","Bob","Lee","Miroslav","Nicolas","Peter"
+        };
+
+        public static void Generate(int repeats, TextWriter target)
+        {
+            Random rnd = new Random();
+
+            for (int i = 0; i < repeats; i++)
+            {
+                int nWord = rnd.Next(words.Length);
+                int nNumber = rnd.Next();
+
+                string name = words[nWord] + nNumber.ToString();
+                string str = ".method public static void " + name + "() cil managed { } ";
+                target.Write(str);
+
+                nWord = rnd.Next(words.Length);
+                nNumber = rnd.Next();
+                str = "//" + words[nWord] + nNumber.ToString();
+                target.WriteLine(str);
+            }
+
+            target.Flush();
+        }
+
+        public static string Generate(int repeats)
+        {
+            StringBuilder sb = new StringBuilder(5000);
+            StringWriter wr = new StringWriter(sb);
+            Generate(repeats, wr);
+            return sb.ToString();
+        }
+    }
+    
     [TestClass]
     public class SyntaxReaderTests
     {
@@ -180,6 +217,28 @@ namespace CilView.Tests
             wr.Flush();
             string processed = sb.ToString();
             Assert.AreEqual(src, processed);
+        }
+        
+        [TestMethod]
+        public void Test_SyntaxReader_LargeText()
+        {
+            // Generate random large source
+            string src = FakeILGenerator.Generate(15000);
+            SyntaxNode[] nodes = SyntaxReader.ReadAllNodes(src);
+            
+            // Just verify that it does not crash and produce reasonable results
+            bool found = false;
+            
+            for (int i=0; i<nodes.Length; i++)
+            {
+                if(nodes[i] is KeywordSyntax && (nodes[i] as KeywordSyntax).Content == "static")
+                {
+                    found = true;
+                    break;
+                }
+            }
+            
+            Assert.IsTrue(found);
         }
     }
 }

--- a/tests/CilView.Tests/SyntaxReaderTests.cs
+++ b/tests/CilView.Tests/SyntaxReaderTests.cs
@@ -6,48 +6,12 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using CilTools.Syntax;
+using CilTools.Tests.Common;
 using CilView.Core.Syntax;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace CilView.Tests
 {
-    public static class FakeILGenerator
-    {
-        static string[] words = {
-            "Test","Foo","Bar","Buzz","Frobby","Bobby","Hello","Alice","Bob","Lee","Miroslav","Nicolas","Peter"
-        };
-
-        public static void Generate(int repeats, TextWriter target)
-        {
-            Random rnd = new Random();
-
-            for (int i = 0; i < repeats; i++)
-            {
-                int nWord = rnd.Next(words.Length);
-                int nNumber = rnd.Next();
-
-                string name = words[nWord] + nNumber.ToString();
-                string str = ".method public static void " + name + "() cil managed { } ";
-                target.Write(str);
-
-                nWord = rnd.Next(words.Length);
-                nNumber = rnd.Next();
-                str = "//" + words[nWord] + nNumber.ToString();
-                target.WriteLine(str);
-            }
-
-            target.Flush();
-        }
-
-        public static string Generate(int repeats)
-        {
-            StringBuilder sb = new StringBuilder(5000);
-            StringWriter wr = new StringWriter(sb);
-            Generate(repeats, wr);
-            return sb.ToString();
-        }
-    }
-    
     [TestClass]
     public class SyntaxReaderTests
     {
@@ -223,7 +187,7 @@ namespace CilView.Tests
         public void Test_SyntaxReader_LargeText()
         {
             // Generate random large source
-            string src = FakeILGenerator.Generate(15000);
+            string src = Utils.GenerateFakeIL(15000);
             SyntaxNode[] nodes = SyntaxReader.ReadAllNodes(src);
             
             // Just verify that it does not crash and produce reasonable results


### PR DESCRIPTION
Disable formatted view for .il files larger then 1 MB because processing them slows down app & consumes tons of memory